### PR TITLE
Fix default should be last one error

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,13 +22,13 @@
   "type": "module",
   "exports": {
     ".": {
-      "default": "./dist/marcelle.esm.js",
       "browser": {
         "import": "./dist/marcelle.esm.js",
         "require": "./dist/marcelle.bundle.umd.js"
       },
       "import": "./dist/marcelle.esm.js",
-      "require": "./dist/marcelle.bundle.umd.js"
+      "require": "./dist/marcelle.bundle.umd.js",
+      "default": "./dist/marcelle.esm.js"
     },
     "./dist/marcelle.css": "./dist/marcelle.css"
   },


### PR DESCRIPTION
fix "Module not found: Error: Default condition should be last one" after installed from npm and imported in project

OS: Linux 
Node: v16.18.0 (npm v8.19.2)
Bundle: Webpack v5
